### PR TITLE
fix scenario security rules looping issue

### DIFF
--- a/api/backgroundjobs/openstackjobs.py
+++ b/api/backgroundjobs/openstackjobs.py
@@ -21,7 +21,7 @@ def create_sec_group(cloudconfig: CloudConfig, lab_id, lab_slice: Slice, scenari
         new_cloud_attrs = lab_slice.cloud_attrs
         new_cloud_attrs['sec_group_id'] = sec_group_id
         lab_slice.update(cloud_attrs=new_cloud_attrs.value)
-        for rule in scenario.sg_rules:
+        for rule in scenario.sg_rules.value:
             _add_security_group_rule(openstack, sec_group_id, rule)
         return sec_group_id
     except Exception as ex:


### PR DESCRIPTION
There's a bug in the `postgrespy`'s ArrayField. The ArrayField object does not reset the index every time it is iterated. And the `rq` seems to iterate the `scenario.sg_rules` when passing it through the redis, thus preventing the following functions from iterating it.

Here is a proof-of-concept example:

```py
import fields
x = fields.ArrayField([1,2,3])
for i in x:
    print(i)

# 1
# 2
# 3

for i in x:
    print(i)
# nothing
```